### PR TITLE
Change version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ob-kb-funnel",
-  "version": "6.0",
+  "version": "6.0.0",
   "kibana": {
     "version": "kibana"
   },


### PR DESCRIPTION
The version number can only be like \d+\.\d+\.\d+,so 6.0 is not valid.