### PR TITLE
Make ob-kb-funnel to work with Kibana 7.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "ob-kb-funnel",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "Visualization of a funnel in Kibana",
   "license": "MIT",
   "main": "index.js",
   "kibana": {
-    "version": "7.4.0",
+    "version": "7.5.0",
     "templateVersion": "1.0.0"
   },
   "scripts": {

--- a/public/funnel_visualization.js
+++ b/public/funnel_visualization.js
@@ -6,8 +6,8 @@ import { Notifier } from 'ui/notify';
 import numeral from 'numeral';
 import D3Funnel from 'd3-funnel';
 
-export const FunnelVisualizationProvider = (Private) => {
-  const queryFilter = Private(FilterBarQueryFilterProvider);
+export const FunnelVisualizationProvider = () => {
+  const queryFilter = FilterBarQueryFilterProvider;
   const filterGen = getFilterGenerator(queryFilter);
   // const notify = new Notifier({ location: 'Funnel' });
 
@@ -28,7 +28,7 @@ export const FunnelVisualizationProvider = (Private) => {
       // this.filterManager = filterManager;
     }
 
-    async render(response) {
+    render(response) {
       console.log("Renering ", response);
       if (!this.container) return;
       this.chart.destroy();

--- a/public/ob-kb-funnel.js
+++ b/public/ob-kb-funnel.js
@@ -1,23 +1,23 @@
-import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
-import { VisFactoryProvider } from 'ui/vis/vis_factory';
+//import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
+import { visFactory  } from 'ui/vis/vis_factory';
 import { Schemas, VisSchemasProvider } from 'ui/vis/editors/default/schemas';
 import { Status } from 'ui/vis/update_status';
-
+import {setup, start} from '../../../src/legacy/core_plugins/visualizations/public/np_ready/public/legacy';
 import { FunnelVisualizationProvider } from './funnel_visualization';
 
 import './ob-kb-funnel.css';
 import optionsTemplate from './options_template.html';
 
-export function FunnelProvider(Private) {
-  const VisFactory = Private(VisFactoryProvider);
-  const _Schemas = Schemas || Private(VisSchemasProvider);
+export function FunnelProvider() {
+  //const VisFactory = Private(VisFactoryProvider);
+  const _Schemas = Schemas || VisSchemasProvider;
 
-  return new VisFactory.createBaseVisualization({
+  return visFactory.createBaseVisualization({
     name: 'ob-kb-funnel',
     title: 'Funnel View',
     icon: 'logstashFilter',
     description: 'Funnel visualization',
-    visualization: Private(FunnelVisualizationProvider),
+    visualization: FunnelVisualizationProvider(),
     visConfig: {
       defaults: {
         absolute: true,
@@ -73,5 +73,5 @@ export function FunnelProvider(Private) {
     ]
   });
 }
-
-VisTypesRegistryProvider.register(FunnelProvider);
+setup.types.registerVisualization(FunnelProvider);
+//VisTypesRegistryProvider.register(FunnelProvider);


### PR DESCRIPTION
This PR addresses #27 

 - Bump package.json to support kibana 7.5.0
 - Remove VisTypesRegistryProvider imports andr eplace with {setup, start} from legacy/core_plugins... Refer - https://discuss.elastic.co/t/cant-resolve-ui-registry-vis-types-7-5/215056/2
  - Change VisFactoryProviderto visFactory
  - Remove Private argument in Funnelprovider and Funnel Visualization as they are not passed by setup
  - Replace VisTypesRegistryProvider.register() with setup.types.registerVisualization()
  - Remote private argument from FunnelProvider.

**Screenshots**

On Kibana 7.5.1

![image](https://user-images.githubusercontent.com/1255523/81157821-ff5e4c80-8fa4-11ea-8787-45ddefce9fcf.png)

**Note**
I have not rebuilt the plugin since I don't have a proper kibana dev environment setup. Can you please do that after making sure these changes work and make a new release so that everyone gets benefitted?